### PR TITLE
Added a way to remove message handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,13 @@ Carthage/Build
 
 # fastlane
 #
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
 
 fastlane/report.xml
 fastlane/screenshots
+
+# JetBrains
+.idea/**

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installation
 
 Usage
 -----
-Tigon is designed to stay out of your way while still providing you with an easy-to-use communication layer. All you have to do is implement the `TigonMessageHandler` protocol and add your implementer to your contentController by calling `addTigonMessageHandler(_)`. Whatever else you want to do with your `WKWebView` is up to you.
+Tigon is designed to stay out of your way while still providing you with an easy-to-use communication layer. All you have to do is implement the `TigonMessageHandler` protocol and add your implementer to your contentController by calling `addTigonMessageHandler(_)`. Whatever else you want to do with your `WKWebView` is up to you. Just make sure you call `removeTigonMessageHandler()` during `deinit` or you will leak your webView.
 
 Here is an example ViewController that uses Tigon
 ```swift
@@ -42,6 +42,11 @@ import Tigon
 class ExampleViewController: UIViewController {
 
   weak var webView: WKWebView?
+
+  deinit {
+    // Make sure we remove our message handler or we will leak our webView.
+    webView?.configuration.userContentController.removeTigonMessageHandler()
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Tigon/TigonMessageHandler.swift
+++ b/Tigon/TigonMessageHandler.swift
@@ -63,4 +63,17 @@ public extension WKUserContentController {
         let scriptMessageHandler = TigonScriptMessageHandler(delegate: messageHandler)
         addScriptMessageHandler(scriptMessageHandler, name: "tigon")
     }
+    
+    /**
+     A way to remove yourself as the `TigonMessageHandler` for your `WKWebView`.
+     Make sure you do this in the `deinit` of the viewController that holds your `WKWebView`.
+     Failing to call this will cause a leak due to the retain logic between `WKWebView` and `WKUserContentController`
+     
+         deinit {
+             webView?.configuration.userContentController.removeTigonMessageHandler()
+         }
+     */
+    func removeTigonMessageHandler() {
+        removeScriptMessageHandlerForName("tigon")
+    }
 }

--- a/Tigon/TigonScriptMessageHandler.swift
+++ b/Tigon/TigonScriptMessageHandler.swift
@@ -23,8 +23,9 @@ public class TigonScriptMessageHandler: NSObject, WKScriptMessageHandler {
     
     public weak var delegate: TigonMessageHandler?
     
-    init(delegate: TigonMessageHandler) {
+    public init(delegate: TigonMessageHandler) {
         self.delegate = delegate
+        super.init()
     }
     
     public func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {


### PR DESCRIPTION
If you don't remove you message handler, you will leak your webView. This PR adds a helper method for removing your message handler and updates the README to reflect that
