### PR TITLE
Update for Swift 3

### DIFF
--- a/Tigon.xcodeproj/project.pbxproj
+++ b/Tigon.xcodeproj/project.pbxproj
@@ -167,11 +167,11 @@
 				TargetAttributes = {
 					723AB7541CAED7530028E70A = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					723AB75E1CAED7530028E70A = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};
@@ -356,7 +356,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -375,7 +375,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartthings.Tigon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -386,7 +386,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartthings.TigonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -397,7 +397,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartthings.TigonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Tigon/TigonError.swift
+++ b/Tigon/TigonError.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 /// An ErrorType used when parsing a message fails.
-public enum TigonError: ErrorType {
+public enum TigonError: Error {
     /// The message identifier was missing or malformed.
-    case InvalidId
+    case invalidId
     /// The message payload was missing or malformed.
-    case InvalidPayload
+    case invalidPayload
     /// The message was unreadable.
-    case UnexpectedMessageFormat
+    case unexpectedMessageFormat
 }

--- a/Tigon/TigonMessageHandler.swift
+++ b/Tigon/TigonMessageHandler.swift
@@ -23,7 +23,7 @@ public protocol TigonMessageHandler: WKScriptMessageHandler {
      - seealso:
       [tigon-js](https://github.com/SmartThingsOSS/tigon-js/)
     */
-    func handleMessage(id: String, payload: AnyObject)
+    func handleMessage(_ id: String, payload: AnyObject)
 
     /**
      A way to receive errors when a `Tigon` fails to handle a message.
@@ -32,12 +32,12 @@ public protocol TigonMessageHandler: WKScriptMessageHandler {
         - error: The error that occurred while trying to parse the message
         - message: The `WKScriptMessage` that couldn't be parsed.
      */
-    func messageError(error: ErrorType, message: WKScriptMessage)
+    func messageError(_ error: TigonError, message: WKScriptMessage)
 }
 
 public extension TigonMessageHandler {
     /// The default implementation for `messageError(_:message:)`
-    func messageError(error: TigonError, message: WKScriptMessage) {
+    func messageError(_ error: TigonError, message: WKScriptMessage) {
         print("\(error): \(message.body)")
     }
 }
@@ -59,9 +59,9 @@ public extension WKUserContentController {
          let webView = WKWebView(frame: CGRectZero, configuration: configuration)
 
     */
-    func addTigonMessageHandler(messageHandler: TigonMessageHandler) {
+    func addTigonMessageHandler(_ messageHandler: TigonMessageHandler) {
         let scriptMessageHandler = TigonScriptMessageHandler(delegate: messageHandler)
-        addScriptMessageHandler(scriptMessageHandler, name: "tigon")
+        add(scriptMessageHandler, name: "tigon")
     }
     
     /**
@@ -74,6 +74,6 @@ public extension WKUserContentController {
          }
      */
     func removeTigonMessageHandler() {
-        removeScriptMessageHandlerForName("tigon")
+        removeScriptMessageHandler(forName: "tigon")
     }
 }

--- a/Tigon/TigonScriptMessageHandler.swift
+++ b/Tigon/TigonScriptMessageHandler.swift
@@ -19,38 +19,40 @@ import WebKit
  seealso:
   [stackoverflow - WKWebView causes my view controller to leak](http://stackoverflow.com/questions/26383031/wkwebview-causes-my-view-controller-to-leak)
 */
-public class TigonScriptMessageHandler: NSObject, WKScriptMessageHandler {
+open class TigonScriptMessageHandler: NSObject, WKScriptMessageHandler {
     
-    public weak var delegate: TigonMessageHandler?
+    open weak var delegate: TigonMessageHandler?
     
     public init(delegate: TigonMessageHandler) {
         self.delegate = delegate
         super.init()
     }
     
-    public func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    open func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         
         guard message.name == "tigon" else {
             // not a tigon message; allow WKScriptMessageHandler to do it's thing
-            delegate?.userContentController(userContentController, didReceiveScriptMessage: message)
+            delegate?.userContentController(userContentController, didReceive: message)
             return
         }
         
         do {
             guard var body = message.body as? [String: AnyObject] else {
-                throw TigonError.UnexpectedMessageFormat
+                throw TigonError.unexpectedMessageFormat
             }
             guard let id = body["id"] as? String else {
-                throw TigonError.InvalidId
+                throw TigonError.invalidId
             }
             guard let payload = body["payload"] else {
-                throw TigonError.InvalidPayload
+                throw TigonError.invalidPayload
             }
             
             delegate?.handleMessage(id, payload: payload)
             
-        } catch {
+        } catch let error as TigonError {
             delegate?.messageError(error, message: message)
+        } catch {
+            // do something here?
         }
     }
 }

--- a/TigonTests/TigonExecutorTests.swift
+++ b/TigonTests/TigonExecutorTests.swift
@@ -22,7 +22,7 @@ class TigonExecutorTests: XCTestCase {
         let configuration = WKWebViewConfiguration()
         configuration.userContentController = contentController
         
-        webView = WKWebView(frame: CGRectZero, configuration: configuration)
+        webView = WKWebView(frame: CGRect.zero, configuration: configuration)
     }
     
     override func tearDown() {
@@ -32,16 +32,16 @@ class TigonExecutorTests: XCTestCase {
     
     // MARK: stringifyResponse tests
     class MockTigonMessageHandler: NSObject, TigonMessageHandler {
-        func handleMessage(id: String, payload: AnyObject) {}
-        func messageError(error: TigonError, message: WKScriptMessage) {}
-        func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {}
+        func handleMessage(_ id: String, payload: AnyObject) {}
+        func messageError(_ error: Error, message: WKScriptMessage) {}
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
     }
     
     func testStringifyResponseDictionary() {
         let testObject = ["an": "array"]
         let expectedResult: String? = "{\n  \"an\" : \"array\"\n}"
         
-        let result = webView.stringifyResponse(testObject)
+        let result = webView.stringifyResponse(testObject as AnyObject)
         
         XCTAssertEqual(result, expectedResult)
     }
@@ -50,7 +50,7 @@ class TigonExecutorTests: XCTestCase {
         let testObject = ["an", "array"]
         let expectedResult: String? = "[\n  \"an\",\n  \"array\"\n]"
         
-        let result = webView.stringifyResponse(testObject)
+        let result = webView.stringifyResponse(testObject as AnyObject)
         
         XCTAssertEqual(result, expectedResult)
     }
@@ -59,7 +59,7 @@ class TigonExecutorTests: XCTestCase {
         let testObject = "a string"
         let expectedResult: String? = "{\n  \"response\" : \"a string\"\n}"
         
-        let result = webView.stringifyResponse(testObject)
+        let result = webView.stringifyResponse(testObject as AnyObject)
         
         XCTAssertEqual(result, expectedResult)
     }
@@ -77,18 +77,18 @@ class TigonExecutorTests: XCTestCase {
         let expectedTrue: String? = "{\n  \"response\" : true\n}"
         let expectedFalse: String? = "{\n  \"response\" : false\n}"
         
-        let trueResult = webView.stringifyResponse(true)
-        let falseResult = webView.stringifyResponse(false)
+        let trueResult = webView.stringifyResponse(true as AnyObject)
+        let falseResult = webView.stringifyResponse(false as AnyObject)
         
         XCTAssertEqual(trueResult, expectedTrue)
         XCTAssertEqual(falseResult, expectedFalse)
     }
     
     func testStringifyResponseFailureReturnsEmptyObject() {
-        let testObject = NSDate()
+        let testObject = Date()
         let expectedResult: String? = "{}"
         
-        let result = webView.stringifyResponse(testObject)
+        let result = webView.stringifyResponse(testObject as AnyObject)
         
         XCTAssertEqual(result, expectedResult)
     }

--- a/TigonTests/TigonScriptMessageHandlerTests.swift
+++ b/TigonTests/TigonScriptMessageHandlerTests.swift
@@ -31,30 +31,30 @@ class TigonScriptMessageHandlerTests: XCTestCase {
         
         var didReceiveScriptMessage: WKScriptMessage? = nil
         
-        func handleMessage(id: String, payload: AnyObject) {
+        func handleMessage(_ id: String, payload: AnyObject) {
             messageId = id
             messagePayload = payload
         }
-        func messageError(error: TigonError, message: WKScriptMessage) {
+        func messageError(_ error: TigonError, message: WKScriptMessage) {
             messageError = error
             messageErrorMessage = message
         }
-        func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
             didReceiveScriptMessage = message
         }
     }
     
     class MockScriptMessage: WKScriptMessage {
         
-        let mockBody: AnyObject
+        let mockBody: Any
         let mockName: String
         
-        init(name: String, body: AnyObject) {
+        init(name: String, body: Any) {
             mockName = name
             mockBody = body
         }
         
-        override var body: AnyObject {
+        override var body: Any {
             return mockBody
         }
         
@@ -66,10 +66,10 @@ class TigonScriptMessageHandlerTests: XCTestCase {
     func testDidReceiveScriptMessage_nonTigonMessages_areSentThroughDidReceiveScriptMessage() {
         let messageHandler = MockTigonMessageHandler()
         let scriptMessageHandler = TigonScriptMessageHandler(delegate: messageHandler)
-        let mockMessage = MockScriptMessage(name: "test", body: "some non-tigon message")
+        let mockMessage = MockScriptMessage(name: "test", body: "some non-tigon message" as AnyObject)
         
         // pass a mock object to the scriptMessageHandler and verify that it passed it along to our other mocked object
-        scriptMessageHandler.userContentController(WKUserContentController(), didReceiveScriptMessage: mockMessage)
+        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
         
         XCTAssertNotNil(messageHandler.didReceiveScriptMessage)
         XCTAssertEqual(messageHandler.didReceiveScriptMessage?.name, "test")
@@ -79,13 +79,13 @@ class TigonScriptMessageHandlerTests: XCTestCase {
     func testDidReceiveScriptMessage_messagesWithUnexpectedMessageBody_areSentThroughMessageError() {
         let messageHandler = MockTigonMessageHandler()
         let scriptMessageHandler = TigonScriptMessageHandler(delegate: messageHandler)
-        let mockMessage = MockScriptMessage(name: "tigon", body: "some non-tigon message")
+        let mockMessage = MockScriptMessage(name: "tigon", body: "some non-tigon message" as AnyObject)
         
         // pass a mock object to the scriptMessageHandler and verify that it passed it along to our other mocked object
-        scriptMessageHandler.userContentController(WKUserContentController(), didReceiveScriptMessage: mockMessage)
+        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
         
         XCTAssertNotNil(messageHandler.messageError)
-        XCTAssertEqual(messageHandler.messageError, TigonError.UnexpectedMessageFormat)
+        XCTAssertEqual(messageHandler.messageError, TigonError.unexpectedMessageFormat)
         XCTAssertNotNil(messageHandler.messageErrorMessage)
         XCTAssertEqual(messageHandler.messageErrorMessage, mockMessage)
     }
@@ -96,10 +96,10 @@ class TigonScriptMessageHandlerTests: XCTestCase {
         let mockMessage = MockScriptMessage(name: "tigon", body: ["id": 5, "payload": "some message"])
         
         // pass a mock object to the scriptMessageHandler and verify that it passed it along to our other mocked object
-        scriptMessageHandler.userContentController(WKUserContentController(), didReceiveScriptMessage: mockMessage)
+        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
         
         XCTAssertNotNil(messageHandler.messageError)
-        XCTAssertEqual(messageHandler.messageError, TigonError.InvalidId)
+        XCTAssertEqual(messageHandler.messageError, TigonError.invalidId)
         XCTAssertNotNil(messageHandler.messageErrorMessage)
         XCTAssertEqual(messageHandler.messageErrorMessage, mockMessage)
     }
@@ -110,10 +110,10 @@ class TigonScriptMessageHandlerTests: XCTestCase {
         let mockMessage = MockScriptMessage(name: "tigon", body: ["id": "test"])
         
         // pass a mock object to the scriptMessageHandler and verify that it passed it along to our other mocked object
-        scriptMessageHandler.userContentController(WKUserContentController(), didReceiveScriptMessage: mockMessage)
+        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
         
         XCTAssertNotNil(messageHandler.messageError)
-        XCTAssertEqual(messageHandler.messageError, TigonError.InvalidPayload)
+        XCTAssertEqual(messageHandler.messageError, TigonError.invalidPayload)
         XCTAssertNotNil(messageHandler.messageErrorMessage)
         XCTAssertEqual(messageHandler.messageErrorMessage, mockMessage)
     }
@@ -124,7 +124,7 @@ class TigonScriptMessageHandlerTests: XCTestCase {
         let mockMessage = MockScriptMessage(name: "tigon", body: ["id": "test", "payload": "some message"])
         
         // pass a mock object to the scriptMessageHandler and verify that it passed it along to our other mocked object
-        scriptMessageHandler.userContentController(WKUserContentController(), didReceiveScriptMessage: mockMessage)
+        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
         
         XCTAssertNotNil(messageHandler.messageId)
         XCTAssertEqual(messageHandler.messageId, "test")


### PR DESCRIPTION
There are two aspects of these changes that I wasn't sure about:

1) The `TigonError` changes, where there was a mix of `TigonError` and `Error` for implementations of a protocol method. I changed the protocol method's parameter to `TigonError` and stopped passing other errors via that method.
2) Requiring `as AnyObject` for the argument to `stringifyResponse`. It could just take an `Any` instead.